### PR TITLE
soju/eng-1789-add-1-bgt-minimum

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -193,6 +193,7 @@ export const QUESTS_CONFIG: Record<string, Record<string, QuestConfig>> = {
           filterCriteria: {
             validator: THJ_VALIDATOR_ADDRESS,
           },
+          requiredAmount: parseEther("1"),
         },
       ],
       startTime: 1722183600,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a required amount of 1 ETH to the constants file and sets the start time to 1722183600.

### Detailed summary
- Added a `requiredAmount` of 1 ETH to constants file
- Set the `startTime` to 1722183600

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->