### PR TITLE
add start block for better filtering and beardrops quest

### DIFF
--- a/db/migrations/1725420800425-Data.js
+++ b/db/migrations/1725420800425-Data.js
@@ -1,8 +1,8 @@
-module.exports = class Data1725343351319 {
-    name = 'Data1725343351319'
+module.exports = class Data1725420800425 {
+    name = 'Data1725420800425'
 
     async up(db) {
-        await db.query(`CREATE TABLE "quest_step" ("id" character varying NOT NULL, "step_number" integer NOT NULL, "types" text array NOT NULL, "addresses" text array NOT NULL, "filter_criteria" jsonb, "required_amount" numeric NOT NULL, "include_transaction" boolean NOT NULL, "path" text, "quest_id" character varying, CONSTRAINT "PK_2701eac9024314902255b9efaf7" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE TABLE "quest_step" ("id" character varying NOT NULL, "step_number" integer NOT NULL, "types" text array NOT NULL, "addresses" text array NOT NULL, "filter_criteria" jsonb, "required_amount" numeric NOT NULL, "include_transaction" boolean NOT NULL, "start_block" integer, "path" text, "quest_id" character varying, CONSTRAINT "PK_2701eac9024314902255b9efaf7" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_9dc3e0b37118e6c7035a54d9d9" ON "quest_step" ("quest_id") `)
         await db.query(`CREATE TABLE "quest" ("id" character varying NOT NULL, "name" text NOT NULL, "chain" text NOT NULL, "start_time" integer, "end_time" integer, "total_participants" integer NOT NULL, "total_completions" integer NOT NULL, CONSTRAINT "PK_0d6873502a58302d2ae0b82631c" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_27eab628270ea2fa9e514693e4" ON "quest" ("name") `)

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,6 +18,7 @@ type QuestStep @entity {
   filterCriteria: JSON
   requiredAmount: BigInt!
   includeTransaction: Boolean!
+  startBlock: Int
   path: String
 }
 

--- a/squid.yaml
+++ b/squid.yaml
@@ -1,6 +1,6 @@
 manifestVersion: subsquid.io/v0.1
 name: quest-squid
-version: 31
+version: 33
 description: A squid that indexes quest events for Cub Scouts
 build:
 deploy:

--- a/src/common/main.ts
+++ b/src/common/main.ts
@@ -69,6 +69,7 @@ function scheduleInit(
       questStep.requiredAmount = stepConfig.requiredAmount || 1n;
       questStep.includeTransaction = stepConfig.includeTransaction || false;
       questStep.path = stepConfig.path;
+      questStep.startBlock = stepConfig.startBlock; // Add this line
       quest.steps.push(questStep);
       questSteps.set(stepId, questStep);
     });

--- a/src/common/processorFactory.ts
+++ b/src/common/processorFactory.ts
@@ -21,7 +21,13 @@ export function createProcessor(chain: CHAINS) {
   const questConfig = QUESTS_CONFIG[chain];
   const addressToTopics: Record<
     string,
-    { topic0: string[]; topic1?: string; topic2?: string }
+    { 
+      topic0: string[]; 
+      topic1?: string; 
+      topic2?: string;
+      range?: { from: number; to?: number };
+      includeTransaction: boolean; // Add this line
+    }
   > = {};
 
   // Collect relevant addresses and topics
@@ -31,7 +37,20 @@ export function createProcessor(chain: CHAINS) {
       for (const address of step.addresses) {
         const lowerCaseAddress = address.toLowerCase();
         if (!addressToTopics[lowerCaseAddress]) {
-          addressToTopics[lowerCaseAddress] = { topic0: [] };
+          addressToTopics[lowerCaseAddress] = { 
+            topic0: [], 
+            includeTransaction: false // Initialize to false
+          };
+        }
+
+        // Add range if startBlock is defined
+        if (step.startBlock) {
+          addressToTopics[lowerCaseAddress].range = { from: step.startBlock };
+        }
+
+        // Set includeTransaction if it's true in the step
+        if (step.includeTransaction) {
+          addressToTopics[lowerCaseAddress].includeTransaction = true;
         }
 
         for (const questType of questTypes) {
@@ -80,7 +99,8 @@ export function createProcessor(chain: CHAINS) {
       topic0: topics.topic0,
       topic1: topics.topic1 ? [topics.topic1] : undefined,
       topic2: topics.topic2 ? [topics.topic2] : undefined,
-      transaction: true, // Include transaction for all logs to be safe
+      range: topics.range,
+      transaction: topics.includeTransaction, // Use the flag here
     });
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,7 @@ export enum QUESTS {
   LEFT_CURVE_BERAS = "Left Curve Beras",
   A_VASE_FULL_OF_HONEY = "A Vase full of Honey",
   OHA_BERA = "おはベラ!",
+  BEARDROPS = "Beardrops",
 }
 
 export enum MISSIONS {
@@ -221,6 +222,7 @@ type QuestStepConfig = {
   readonly requiredAmount?: bigint;
   readonly includeTransaction?: boolean;
   readonly path?: string;
+  readonly startBlock?: number;
 };
 
 type QuestConfig = {
@@ -315,32 +317,37 @@ export const QUESTS_CONFIG: Record<string, Record<string, QuestConfig>> = {
       startTime: 1724367186,
       endTime: 1725480000,
     },
-    // [QUESTS.STAKOOOR]: {
-    //   steps: [
-    //     {
-    //       type: QUEST_TYPES.STAKE,
-    //       address: REWARDS_VAULT_ADDRESS,
-    //     },
-    //   ],
-    //   startTime: 1722183600,
-    // },
-    // [QUESTS.DELEGATOOOR]: {
-    //   steps: [
-    //     {
-    //       type: QUEST_TYPES.CLAIM_BGT_REWARD,
-    //       address: REWARDS_VAULT_ADDRESS,
-    //     },
-    //     {
-    //       type: QUEST_TYPES.DELEGATE,
-    //       address: BGT_ADDRESS,
-    //       filterCriteria: {
-    //         validator: THJ_VALIDATOR_ADDRESS,
-    //       },
-    //       requiredAmount: parseEther("1"),
-    //     },
-    //   ],
-    //   startTime: 1722183600,
-    // },
+    [QUESTS.STAKOOOR]: {
+      steps: [
+        {
+          types: [QUEST_TYPES.STAKE],
+          addresses: [REWARDS_VAULT_ADDRESS],
+          startBlock: 3853226,
+        },
+      ],
+      startTime: 1725480000 - ONE_DAY_IN_SECONDS,
+    },
+    [QUESTS.DELEGATOOOR]: {
+      steps: [
+        {
+          types: [QUEST_TYPES.CLAIM_BGT_REWARD],
+          addresses: [REWARDS_VAULT_ADDRESS],
+          startBlock: 3853226,
+        },
+        {
+          types: [QUEST_TYPES.DELEGATE],
+          addresses: [BGT_ADDRESS],
+          filterCriteria: {
+            [QUEST_TYPES.DELEGATE]: {
+              validator: THJ_VALIDATOR_ADDRESS,
+            },
+          },
+          requiredAmount: parseEther("1"),
+          startBlock: 3853226,
+        },
+      ],
+      startTime: 1725480000 - ONE_DAY_IN_SECONDS,
+    },
     [QUESTS.RUN_IT_BACK_TURBO]: {
       steps: [
         {
@@ -521,6 +528,21 @@ export const QUESTS_CONFIG: Record<string, Record<string, QuestConfig>> = {
     },
   },
   [CHAINS.ARBITRUM]: {
+    [QUESTS.BEARDROPS]: {
+      steps: [
+        {
+          types: [QUEST_TYPES.ERC1155_MINT],
+          addresses: [HONEY_SITE_ADDRESS],
+          filterCriteria: {
+            [QUEST_TYPES.ERC1155_MINT]: {
+              id: 2n,
+            },
+          },
+        },
+      ],
+      startTime: 1725480000 - ONE_DAY_IN_SECONDS,
+      endTime: 1726344000,
+    },
     [QUESTS.A_VASE_FULL_OF_HONEY]: {
       steps: [
         {

--- a/src/model/generated/questStep.model.ts
+++ b/src/model/generated/questStep.model.ts
@@ -32,6 +32,9 @@ export class QuestStep {
     @BooleanColumn_({nullable: false})
     includeTransaction!: boolean
 
+    @IntColumn_({nullable: true})
+    startBlock!: number | undefined | null
+
     @StringColumn_({nullable: true})
     path!: string | undefined | null
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a `startBlock` field to `questStep` in the schema and updates related files for better quest event indexing.

### Detailed summary
- Added `startBlock` field to `questStep` in `schema.graphql`
- Updated `questStep.model.ts` to include `startBlock` property
- Added `startBlock` assignment in `processorFactory.ts`
- Updated `Data.js` migration to include `start_block` field
- Added `BEARDROPS` mission in `constants.ts` with `startBlock`
- Updated quest configurations with `startBlock` for specific quests

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->